### PR TITLE
Add bear

### DIFF
--- a/images/clang-toolchain/Dockerfile
+++ b/images/clang-toolchain/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:focal AS base
 RUN apt-get update -q
 RUN apt-get update -q && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+	bear \
 	cmake \
 	clang-format-11 \
 	clang-tidy-11 \

--- a/images/clang-toolchain/test.bash
+++ b/images/clang-toolchain/test.bash
@@ -10,6 +10,7 @@ it_has_executables() {
 	type -p git
 	type -p parallel
 	type -p ninja
+	type -p bear
 }
 
 _main() {


### PR DESCRIPTION
This enables us to capture the compile commands for the gpopt translator
and run clang-tidy over it in CI.