### PR TITLE
Add flex and bison to (minimally) build Greenplum

### DIFF
--- a/images/clang-toolchain/Dockerfile
+++ b/images/clang-toolchain/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:focal AS base
 RUN apt-get update -q
 RUN apt-get update -q && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 	bear \
+	ccache \
+	bison \
+	flex \
 	cmake \
 	clang-format-11 \
 	clang-tidy-11 \

--- a/images/clang-toolchain/test.bash
+++ b/images/clang-toolchain/test.bash
@@ -3,9 +3,12 @@
 set -e -u -o pipefail
 
 it_has_executables() {
+	type -p bison flex
+	type -p ccache
 	type -p cmake
 	type -p clang-format-11
 	type -p clang-tidy-11
+	type -p clang++-11 clang-11
 	type -p xargs
 	type -p git
 	type -p parallel


### PR DESCRIPTION
This makes the configure script happy when we disable a whole bunch of
unrelated features and enables building `src/backend/gpopt`.